### PR TITLE
Use "/u/" instead of "/l/" as redirect prefix

### DIFF
--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -1,7 +1,7 @@
 class LinksController < ApplicationController
   def show
     link = Link.find(params[:id])
-    @url = URI.join(host_prefix, link.id.to_s).to_s
+    @url = redirect_url(link)
   end
 
   def create
@@ -20,9 +20,5 @@ class LinksController < ApplicationController
     if link.missing_scheme?
       link.url = "http://" + link.url
     end
-  end
-
-  def host_prefix
-    "http://#{request.host_with_port}/l/"
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,5 +2,5 @@ Rails.application.routes.draw do
   resources :links, only: [:create, :show]
   root "homes#index"
 
-  get "/l/:id" => "redirects#show"
+  get "/l/:id" => "redirects#show", as: :redirect
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,5 +2,5 @@ Rails.application.routes.draw do
   resources :links, only: [:create, :show]
   root "homes#index"
 
-  get "/l/:id" => "redirects#show", as: :redirect
+  get "/u/:id" => "redirects#show", as: :redirect
 end

--- a/spec/features/user_shortens_a_url_spec.rb
+++ b/spec/features/user_shortens_a_url_spec.rb
@@ -8,7 +8,7 @@ feature "User shortens a URL" do
     click_on "Shorten!"
 
     link = Link.last
-    expected_url = "http://www.example.com/l/#{link.id}"
+    expected_url = redirect_url(link)
     anchor = find("#link a")
 
     expect(anchor[:href]).to eq expected_url

--- a/spec/requests/redirects_spec.rb
+++ b/spec/requests/redirects_spec.rb
@@ -4,7 +4,7 @@ describe "Redirecting to the original URL" do
   it "redirects to the original URL" do
     link = create(:link, url: "http://gabebw.com")
 
-    get "/l/#{link.id}"
+    get redirect_path(link)
 
     expect(response).to redirect_to link.url
   end


### PR DESCRIPTION
The "l" stood for "link", but in our sans-serif font the "l" is totally indistinguishable from the number "1". Since we are using numbers as the redirect slug, that makes it hard to tell whether the path is "/l/4" (L-4) or "/1/4" (1-4).

Using "/u/" (for "URL") makes the letter immediately distinguishable.
