### PR TITLE
Add app.json file for easy Heroku deploys

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,0 +1,16 @@
+{
+  "name": "Crumple, a URL shortener",
+  "description": "This app shortens URLs.",
+  "scripts": {
+    "postdeploy": "bundle exec rake db:migrate"
+  },
+  "env": {
+    "RACK_ENV": "production",
+    "RAILS_ENV": "production",
+    "SECRET_KEY_BASE": {
+      "description": "A secret key for verifying the integrity of signed cookies.",
+      "generator": "secret"
+    }
+  },
+  "addons": ["heroku-postgresql"]
+}


### PR DESCRIPTION
This file makes it VERY easy to deploy to Heroku. For example, we don't have
to manually wait for the app to finish deploying before running `rake
db:migrate`
-- we can just tell Heroku to run it post-deploy.

Further reading:
- https://devcenter.heroku.com/articles/app-json-schema
  *
  https://devcenter.heroku.com/articles/platform-api-reference#app-setup-create
